### PR TITLE
do not persist ConfirmLoginScreen on browser history

### DIFF
--- a/ui/src/screens/ConfirmLoginScreen.js
+++ b/ui/src/screens/ConfirmLoginScreen.js
@@ -19,7 +19,7 @@ const ConfirmLoginScreen = ({ route, navigation }) => {
     useEffect(() => {
         // Only trigger automatic redirection if we just successfully logged in on this device
         if (status === 'success' && !isCrossDevice) {
-            navigation.navigate('Home');
+            navigation.replace('Home');
         }
     }, [status, isCrossDevice, navigation]);
 
@@ -47,7 +47,7 @@ const ConfirmLoginScreen = ({ route, navigation }) => {
                 await completeLogin(token);
                 setStatus('success');
                 // Automatically redirect to Home for same-device logins
-                navigation.navigate('Home');
+                navigation.replace('Home');
             }
         } catch (e) {
             setStatus('error');


### PR DESCRIPTION
I have updated the ConfirmLoginScreen to use replace navigation instead of push. This ensures that after confirming a login, the confirmation page is removed from the history stack. Now, if a user successfully logs in and then presses the browser's "back" button, they will be taken to the page they were on before the confirmation page (e.g., the new tab page or the login screen), rather than returning to the confirmation page and seeing a "Token Expired" error.

This behavior applies to both automatic redirects and manual confirmations on the same device. Cross-device confirmations retain their existing behavior (showing a success message with a button to continue to the app).